### PR TITLE
fix: align labeler globs with assets layout

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,11 @@
 # 文档相关的标签
 documentation:
   - changed-files:
-    - any-glob-to-any-file: ['i18n/**/*.md', 'README.md', 'CONTRIBUTING.md', 'LICENSE']
+    - any-glob-to-any-file:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'assets/documents/**/*.md'
 
 # CI/CD 工作流相关的标签
 cicd:
@@ -14,9 +18,9 @@ cicd:
 # 提示词相关的标签
 prompt:
   - changed-files:
-    - any-glob-to-any-file: 'i18n/zh/prompts/**/*.md'
+    - any-glob-to-any-file: 'assets/prompts/**/*.md'
 
 # 实战案例相关的标签
 example:
   - changed-files:
-    - any-glob-to-any-file: 'i18n/zh/documents/实战案例/**/*.md'
+    - any-glob-to-any-file: 'assets/documents/case-studies/**/*.md'


### PR DESCRIPTION
## Summary
- update the PR labeler globs from the removed `i18n/...` layout to the current `assets/...` layout
- keep the existing README/license and workflow labels unchanged
- add current paths for `assets/documents`, `assets/prompts`, and `assets/documents/case-studies`

## Why
The repository now stores docs, prompts, and examples under `assets/`, while `.github/labeler.yml` still matches the old `i18n/zh/...` paths. As a result, the existing `pull_request_target` labeler workflow can miss normal content PRs.

## Validation
- parsed `.github/labeler.yml` with PyYAML
- ran `git diff --check -- .github/labeler.yml`
