### PR TITLE
fix: preserve JSONL row numbers in Excel round trip

### DIFF
--- a/assets/repos/prompts-library/main.py
+++ b/assets/repos/prompts-library/main.py
@@ -336,7 +336,7 @@ def run_jsonl_excel_to_jsonl(excel_path: Path, project_root: Path) -> int:
                             sheet_lines.append(json.dumps({
                                 "category_id": cat_id,
                                 "category": cat_name,
-                                "row": row_idx + 2,
+                                "row": row_idx + 1,
                                 "col": col_idx + 1,
                                 "title": obj["title"][:80],
                                 "content": obj["content"]


### PR DESCRIPTION
## What

Fix the Excel(JSONL) → JSONL row metadata calculation so a JSONL → Excel → JSONL round trip preserves the original row number.

`run_jsonl_to_excel()` writes rows with `header=False` and maps JSONL `row=1` to the first worksheet row. When reading that worksheet back with `pandas.read_excel(..., header=None)`, the first data row has zero-based `row_idx == 0`, so the reverse conversion should emit `row_idx + 1`, not `row_idx + 2`.

Before this change, a one-record round trip changed `row: 1` into `row: 2`, which corrupts prompt coordinates used by the prompt-library conversion/restore workflow.

## Validation

- Round-tripped a one-record JSONL through `run_jsonl_to_excel()` and `run_jsonl_excel_to_jsonl()` in a temporary project root and asserted the output kept `row=1`, `col=1`.
- `git diff --check`
- `python3 -m py_compile assets/repos/prompts-library/main.py`

Note: this repository contains both `assets/skills/ccxt/references/Manual.md` and `assets/skills/ccxt/references/manual.md`, which collide on my case-insensitive local filesystem. I did not stage or include those files; the PR diff only changes `assets/repos/prompts-library/main.py`.
