### PR TITLE
fix: support JSONL directory input in prompts-library

### DIFF
--- a/tools/prompts-library/README.md
+++ b/tools/prompts-library/README.md
@@ -10,6 +10,7 @@
 - Markdown -> Excel：把 Markdown 文档目录还原为 Excel 工作簿。
 - Markdown -> JSONL：把 Markdown 提示词转换为 JSONL。
 - JSONL -> Excel：把 JSONL 数据转换为 Excel。
+- JSONL 目录 -> Excel：把 Excel(JSONL) 导出的工作表级 JSONL 目录重新合并为 Excel。
 - Excel(JSONL) -> JSONL：把内部 JSONL 格式的 Excel 按工作表拆成 JSONL 文件。
 
 ## 目录结构
@@ -58,6 +59,7 @@ python3 main.py --select "prompt_excel/example.xlsx" --mode excel2docs
 python3 main.py --select "prompt_docs/example" --mode docs2excel
 python3 main.py --select "prompt_docs/example" --mode docs2jsonl
 python3 main.py --select "prompt_jsonl/example.jsonl" --mode jsonl2excel
+python3 main.py --select "prompt_jsonl/example_2025_1222_004537" --mode jsonl2excel
 python3 main.py --select "prompt_excel/prompt_jsonl.xlsx" --mode jsonl_excel2jsonl
 ```
 

--- a/tools/prompts-library/main.py
+++ b/tools/prompts-library/main.py
@@ -51,6 +51,7 @@ JSONL → Excel 单元格格式:
   - Docs→Excel: ./prompt_excel/prompt_excel_YYYY_MMDD_HHMMSS/rebuilt.xlsx
   - Docs→JSONL: ./prompt_jsonl/{docs_name}.jsonl
   - JSONL→Excel: ./prompt_excel/{jsonl_name}.xlsx
+  - JSONL目录→Excel: ./prompt_excel/{jsonl_dir_name}.xlsx
   - Excel(JSONL)→JSONL: ./prompt_jsonl/{excel_name}_{timestamp}/<sheet>.jsonl
 
 使用示例
@@ -69,6 +70,7 @@ JSONL → Excel 单元格格式:
 
   # JSONL → Excel
   python3 main.py --select "prompt_jsonl/prompt_docs.jsonl"
+  python3 main.py --select "prompt_jsonl/prompt_jsonl_2025_1222_004537" --mode jsonl2excel
 
   # Excel(JSONL) → JSONL（自动检测或显式指定）
   python3 main.py --select "prompt_excel/prompt_jsonl.xlsx"
@@ -108,7 +110,7 @@ except Exception:  # pragma: no cover
 @dataclass
 class Candidate:
     index: int
-    kind: str  # "excel" | "docs" | "docs2jsonl" | "jsonl"
+    kind: str  # "excel" | "docs" | "docs2jsonl" | "jsonl" | "jsonl_dir" | "jsonl_excel"
     path: Path
     label: str
 
@@ -219,6 +221,20 @@ def list_jsonl_files(jsonl_dir: Path) -> List[Path]:
     if not jsonl_dir.exists():
         return []
     return sorted([p for p in jsonl_dir.iterdir() if p.is_file() and p.suffix.lower() == ".jsonl"], key=lambda p: p.stat().st_mtime)
+
+
+def list_jsonl_dirs(jsonl_dir: Path) -> List[Path]:
+    """列出由 Excel(JSONL)→JSONL 生成的 sheet 级 JSONL 目录。"""
+    if not jsonl_dir.exists():
+        return []
+    return sorted(
+        [
+            p
+            for p in jsonl_dir.iterdir()
+            if p.is_dir() and any(child.is_file() and child.suffix.lower() == ".jsonl" for child in p.iterdir())
+        ],
+        key=lambda p: p.stat().st_mtime,
+    )
 
 
 def is_jsonl_excel(excel_path: Path) -> bool:
@@ -383,8 +399,18 @@ def run_jsonl_excel_to_jsonl(excel_path: Path, project_root: Path) -> int:
     return 0
 
 
-def run_jsonl_to_excel(jsonl_path: Path, project_root: Path) -> int:
-    """Convert JSONL to Excel, each cell contains the full JSON object as string."""
+def read_jsonl_records(jsonl_paths: Sequence[Path]) -> List[dict]:
+    import json
+    records = []
+    for jsonl_path in jsonl_paths:
+        with open(jsonl_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                if line.strip():
+                    records.append(json.loads(line))
+    return records
+
+
+def write_records_to_excel(records: List[dict], output_file: Path) -> int:
     import json
     from collections import defaultdict
     try:
@@ -392,56 +418,78 @@ def run_jsonl_to_excel(jsonl_path: Path, project_root: Path) -> int:
     except ImportError:
         print("❌ 需要 pandas: pip install pandas openpyxl")
         return 1
-    
-    records = []
-    with open(jsonl_path, 'r', encoding='utf-8') as f:
-        for line in f:
-            if line.strip():
-                records.append(json.loads(line))
-    
+
     if not records:
-        print(f"❌ JSONL 文件为空: {jsonl_path}")
+        print("❌ JSONL 文件为空")
         return 1
-    
+
     # category -> {row -> {col -> json_string}}
     sheets_data: dict = defaultdict(lambda: defaultdict(dict))
     cat_id_map = {}
-    
+
     for r in records:
         cat_name = r["category"]
         cat_id_map[r["category_id"]] = cat_name
         # 单元格内容只保留 title 和 content
         cell_data = {"title": r["title"], "content": r["content"]}
         sheets_data[cat_name][r["row"]][r["col"]] = json.dumps(cell_data, ensure_ascii=False)
-    
-    output_dir = project_root / "prompt_excel"
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / f"{jsonl_path.stem}.xlsx"
-    
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
     sorted_cats = sorted(cat_id_map.items(), key=lambda x: x[0])
-    
+
     with pd.ExcelWriter(output_file, engine='openpyxl') as writer:
         for cat_id, cat_name in sorted_cats:
             row_data = sheets_data[cat_name]
             if not row_data:
                 continue
-            
+
             max_row = max(row_data.keys())
             max_col = max(c for cols in row_data.values() for c in cols.keys())
-            
+
             data = []
             for row_idx in range(1, max_row + 1):
                 row_list = []
                 for col_idx in range(1, max_col + 1):
                     row_list.append(row_data.get(row_idx, {}).get(col_idx, ""))
                 data.append(row_list)
-            
+
             df = pd.DataFrame(data)
             sheet_name = cat_name[:31]
             df.to_excel(writer, sheet_name=sheet_name, index=False, header=False)
-    
-    print(f"✅ JSONL→Excel OK: {jsonl_path.name} → {output_file.relative_to(project_root)} ({len(sorted_cats)} 个工作表)")
-    return 0
+
+    return len(sorted_cats)
+
+
+def run_jsonl_to_excel(jsonl_path: Path, project_root: Path) -> int:
+    """Convert one JSONL file to Excel, each cell contains the full JSON object as string."""
+    output_dir = project_root / "prompt_excel"
+    output_file = output_dir / f"{jsonl_path.stem}.xlsx"
+    sheet_count = write_records_to_excel(read_jsonl_records([jsonl_path]), output_file)
+    if sheet_count > 0:
+        print(f"✅ JSONL→Excel OK: {jsonl_path.name} → {output_file.relative_to(project_root)} ({sheet_count} 个工作表)")
+        return 0
+    return sheet_count
+
+
+def run_jsonl_dir_to_excel(jsonl_dir: Path, project_root: Path) -> int:
+    """Convert a directory of sheet-level JSONL files back to one Excel workbook."""
+    jsonl_paths = sorted(
+        [p for p in jsonl_dir.iterdir() if p.is_file() and p.suffix.lower() == ".jsonl"],
+        key=lambda p: p.name,
+    )
+    if not jsonl_paths:
+        print(f"❌ JSONL 目录中没有 .jsonl 文件: {jsonl_dir}")
+        return 1
+    output_dir = project_root / "prompt_excel"
+    output_file = output_dir / f"{jsonl_dir.name}.xlsx"
+    sheet_count = write_records_to_excel(read_jsonl_records(jsonl_paths), output_file)
+    if sheet_count > 0:
+        print(
+            f"✅ JSONL目录→Excel OK: {jsonl_dir.name} → "
+            f"{output_file.relative_to(project_root)} ({sheet_count} 个工作表 / {len(jsonl_paths)} 个 JSONL 文件)"
+        )
+        return 0
+    return sheet_count
 
 
 def build_candidates(project_root: Path, excel_dir: Path, docs_dir: Path) -> List[Candidate]:
@@ -468,6 +516,10 @@ def build_candidates(project_root: Path, excel_dir: Path, docs_dir: Path) -> Lis
     for path in list_jsonl_files(jsonl_dir):
         label = f"{path.name}"
         candidates.append(Candidate(index=idx, kind="jsonl", path=path, label=label))
+        idx += 1
+    for path in list_jsonl_dirs(jsonl_dir):
+        label = f"{path.name}/"
+        candidates.append(Candidate(index=idx, kind="jsonl_dir", path=path, label=label))
         idx += 1
     return candidates
 
@@ -508,7 +560,7 @@ def select_interactively(candidates: Sequence[Candidate]) -> Optional[Candidate]
         table.add_column("编号", style="bold yellow", justify="right", width=4)
         table.add_column("类型", style="magenta", width=16)
         table.add_column("路径/名称", style="white")
-        kind_labels = {"excel": "Excel→Docs", "docs": "Docs→Excel", "docs2jsonl": "Docs→JSONL", "jsonl": "JSONL→Excel", "jsonl_excel": "Excel(JSONL)→JSONL"}
+        kind_labels = {"excel": "Excel→Docs", "docs": "Docs→Excel", "docs2jsonl": "Docs→JSONL", "jsonl": "JSONL→Excel", "jsonl_excel": "Excel(JSONL)→JSONL", "jsonl_dir": "JSONL目录→Excel"}
         for c in candidates:
             table.add_row(str(c.index), kind_labels.get(c.kind, c.kind), c.label)
 
@@ -530,7 +582,7 @@ def select_interactively(candidates: Sequence[Candidate]) -> Optional[Candidate]
             console.print("[red]编号不存在，请重试[/red]")
 
     # Plain fallback
-    kind_labels = {"excel": "Excel→Docs", "docs": "Docs→Excel", "docs2jsonl": "Docs→JSONL", "jsonl": "JSONL→Excel", "jsonl_excel": "Excel(JSONL)→JSONL"}
+    kind_labels = {"excel": "Excel→Docs", "docs": "Docs→Excel", "docs2jsonl": "Docs→JSONL", "jsonl": "JSONL→Excel", "jsonl_excel": "Excel(JSONL)→JSONL", "jsonl_dir": "JSONL目录→Excel"}
     print("请选择一个源进行转换：")
     for c in candidates:
         print(f"  {c.index:2d}. [{kind_labels.get(c.kind, c.kind)}] {c.label}")
@@ -596,6 +648,11 @@ def main() -> int:
         if selected.is_file() and selected.suffix.lower() == ".jsonl":
             return run_jsonl_to_excel(selected, repo_root)
         if selected.is_dir():
+            if args.mode == "jsonl2excel" or (
+                selected.parent == (repo_root / "prompt_jsonl").resolve()
+                and any(p.is_file() and p.suffix.lower() == ".jsonl" for p in selected.iterdir())
+            ):
+                return run_jsonl_dir_to_excel(selected, repo_root)
             # Check mode or default to docs2excel
             if args.mode == "docs2jsonl":
                 return run_docs_to_jsonl(selected, repo_root)
@@ -616,6 +673,8 @@ def main() -> int:
         return run_docs_to_jsonl(chosen.path, repo_root)
     elif chosen.kind == "jsonl":
         return run_jsonl_to_excel(chosen.path, repo_root)
+    elif chosen.kind == "jsonl_dir":
+        return run_jsonl_dir_to_excel(chosen.path, repo_root)
     else:
         return run_start_convert(start_convert, mode="docs2excel", project_root=repo_root, select_path=chosen.path, docs_dir=docs_dir)
 


### PR DESCRIPTION
**请描述本次 PR 的类型**
- [x] Bug 修复
- [ ] 功能增加
- [ ] 代码优化/重构
- [ ] 文档更新
- [ ] 其他 (请说明):

**本次 PR 解决了什么问题或增加了什么功能？**

`tools/prompts-library/main.py` 里 `Excel(JSONL)→JSONL` 会输出如下目录形态：

```text
prompt_jsonl/<excel_name>_<timestamp>/<sheet>.jsonl
```

但原来的 `JSONL→Excel` 入口只识别 `prompt_jsonl/` 根目录下的单个 `.jsonl` 文件；当用户想把刚导出的 sheet 级 JSONL 目录还原成 Excel 时，交互列表不会显示这个目录，命令行 `--select <dir> --mode jsonl2excel` 也会按 docs 目录路径处理。

本次改动：

- 增加 `prompt_jsonl/<name>/` 目录发现，让交互列表能显示 JSONL 目录；
- 支持 `--select "prompt_jsonl/<name>" --mode jsonl2excel` 把多个 sheet 级 JSONL 文件合并回一个 Excel；
- 复用原有 JSONL→Excel 的写入逻辑，避免改变单文件 JSONL 的行为；
- 同步 README 中的命令示例。

**相关 Issue**

Related to current prompts-library round-trip behavior; no existing issue found.

**测试步骤**

1. `python3 -m py_compile main.py`
2. 使用临时 venv 安装 `requirements.txt`
3. 创建两个 sheet 级 JSONL 文件：
   - `prompt_jsonl/example_2025_1222_004537/01_A.jsonl`
   - `prompt_jsonl/example_2025_1222_004537/02_B.jsonl`
4. 运行：

```bash
python3 main.py --select "prompt_jsonl/example_2025_1222_004537" --mode jsonl2excel --non-interactive
```

结果：生成 `prompt_excel/example_2025_1222_004537.xlsx`，输出显示 2 个工作表 / 2 个 JSONL 文件。

说明：仓库根目录 `make lint` 在本机未能执行，因为当前 macOS CommandLineTools 的 `xcrun` 动态库架构不匹配（本地环境问题）：

```text
unable to load libxcrun ... incompatible architecture (have 'x86_64', need 'arm64e')
```

**检查列表**
- [x] 我已阅读并遵循项目的贡献指南。
- [x] 我已在本地运行了适用的最小测试。
- [x] 我已确保代码风格与项目保持一致。
- [x] 我已更新了相应的文档 (如果适用)。
- [x] 我已对本次提交进行了有意义的 Commit Message。
